### PR TITLE
Remplacement de 'songs' par 'content'.

### DIFF
--- a/books/matteo.sb
+++ b/books/matteo.sb
@@ -9,7 +9,7 @@
   ],
 "booktype" : "chorded",
 "subtitle" : "Matteo's songs",
-"songs" : [
+"content" : [
     "hubert-felix_thiefaine/sentiments_numeriques_revisites.sg",
     "jean_leloup/promeneur.sg",
     "maxime_le_forestier/parachutiste.sg",

--- a/books/naheulbeuk.sb
+++ b/books/naheulbeuk.sb
@@ -13,7 +13,7 @@
 "subtitle" : "Recueil de chansons non-officiel",
 "title" : "Le Donjon de Naheulbeuk",
 "version" : "0.5",
-"songs" : [
+"content" : [
     "belyscendre/*.sg",
     "le_donjon_de_naheulbeuk/*.sg"
   ],

--- a/books/volume-1.sb
+++ b/books/volume-1.sb
@@ -10,7 +10,7 @@
 "picture" : "feel-the-music",
 "picturecopyright" : "foxygamergirl @ deviantart.com",
 "subtitle" : "Tome 1",
-"songs" : [
+"content" : [
     "alain_bashung/gaby_oh_gaby.sg",
     "amy_macdonald/mr._rock_n_roll.sg",
     "amy_macdonald/this_is_the_life.sg",

--- a/books/volume-2.sb
+++ b/books/volume-2.sb
@@ -10,7 +10,7 @@
 "picture" : "sound",
 "picturecopyright" : "ellesh @ deviantart.com",
 "subtitle" : "Tome 2",
-"songs" : [
+"content" : [
     "aaron/u_turn_lili.sg",
     "alain_souchon/foule_sentimentale.sg",
     "alex_beaupain/je_n_aime_que_toi.sg",

--- a/books/volume-3.sb
+++ b/books/volume-3.sb
@@ -10,7 +10,7 @@
 "picture" : "Mousey_Band_by_Duffzilla",
 "picturecopyright" : "duffzilla @ deviantart.com",
 "subtitle" : "Tome 3",
-"songs" : [
+"content" : [
     "alain_souchon/l_amour_a_la_machine.sg",
     "alanis_morissette/ironic.sg",
     "alex_beaupain/as_tu_deja_aime.sg",

--- a/books/volume-4.sb
+++ b/books/volume-4.sb
@@ -10,7 +10,7 @@
 "picture" : "music_by_lauratheartist",
 "picturecopyright" : "LauraTheArtist @ deviantart.com",
 "subtitle" : "Tome 4",
-"songs" : [
+"content" : [
     "alain_souchon/bidon.sg",
     "ben_e_king/stand_by_me.sg",
     "bill_withers/just_two_of_us.sg",

--- a/books/volume-5.sb
+++ b/books/volume-5.sb
@@ -10,7 +10,7 @@
 "picture" : "The_Music_Machine_by_hit_squad",
 "picturecopyright" : "hit-squad @ deviantart.com",
 "subtitle" : "Tome 5",
-"songs" : [
+"content" : [
     "3_doors_down/here_without_you.sg",
     "adele/rolling_in_the_deep.sg",
     "alain_souchon/la_ballade_de_jim.sg",


### PR DESCRIPTION
À accepter ou refuser suivant la décision de la branche jumelle sur [songbook-core](/patacrep/songbook-core/tree/next-content) : [suivre la décision](/patacrep/songbook-core/pull/22).
