### PR TITLE
Correction de tonalité

### DIFF
--- a/songs/hugues_aufray/santiano.sg
+++ b/songs/hugues_aufray/santiano.sg
@@ -5,24 +5,26 @@
 
 
   \cover
+  \gtab{Em}{022000}
+  \gtab{D}{X00232}
+  \gtab{Bm}{224432}
   \gtab{Am}{X02210}
   \gtab{G}{320003}
-  \gtab{Em}{022000}
-
 
   \begin{verse}
-    C'est \[Am]un fameux trois mâts
-    Fin comme un oi\[G]seau
-    Hissez \[Am]ho ! Santi\[G]ano !
-    Dix-huit nœuds, quatre-cents tonneaux
-    Je suis \[Am]fier d'y \[Em]être \[Am]matelot
+    C'est \[Em]un fameux trois \[G]mâts
+    Fin comme un oi\[D]seau
+    Hissez \[Em]ho ! Santi\[D]ano !
+    \[Am]Dix-huit nœuds, quatre-\[D]cents tonneaux
+    Je suis \[Em]fier d'y \[D]être \[Em]matelot
   \end{verse}
 
   \begin{chorus}
-    Tiens \[Am]bon la vague et tiens bon le \[G]vent
-    Hissez \[Am]ho ! Santi\[G]ano !
-    Si Dieu veut, toujours droit devant
-    Nous ir\[Am]ons jusqu'\[Em]{à San} \[Am]Francisco
+    Tiens \[Em]bon la \[G]vague 
+    Et tiens bon le \[D]vent
+    Hissez \[Em]ho ! Santi\[D]ano !
+    \[Am]Si Dieu veut, toujours \[D]droit devant
+    Nous ir\[Em]ons jusqu'\[D]à San \[Em]Francisco
   \end{chorus}
 
   \begin{verse}

--- a/songs/m/la_seine.sg
+++ b/songs/m/la_seine.sg
@@ -13,30 +13,30 @@
   \lilypond{La_seine_rythm}
 
   \begin{verse*}
-    \musicnote{\nolyrics \Intro : \lilypond{La_seine_riff1} | \[Am] | \[F] | \[C] \[E] | \[Am] |}
+    \musicnote{\nolyrics \Intro : \lilypond{La_seine_riff1} | \[Dm] | \[B&] | \[F] \[A] | \[Dm] |}
   \end{verse*}
 
   \begin{verse}
-    \[Am]Elle sort de son lit \[F]tellement sure d'elle
-    \[C]La Seine, \[E]la Seine, \[Am]la Seine
-    \[Am]Tellement jolie, \[F]elle m'ensorcelle
-    \[C]La Seine, \[E]la Seine, \[Am]la Seine
+    \[Dm]Elle sort de son lit \[B&]tellement sure d'elle
+    \[F]La Seine, \[A]la Seine, \[Dm]la Seine
+    \[Dm]Tellement jolie, \[B&]elle m'ensorcelle
+    \[F]La Seine, \[A]la Seine, \[Dm]la Seine
   \end{verse}
 
   \begin{repeatedchords}
     \begin{verse}
-      \[Am]Extralucide, la \[F]Lune est sure
-      \[C]La Seine, \[E]la Seine, \[Am]la Seine
-      \[Am]Tu n'es pas saoul, \[F]Paris est sous
-      \[C]La Seine, \[E]la Seine, \[Am]la Seine
+      \[Dm]Extralucide, la \[B&]Lune est sure
+      \[F]La Seine, \[A]la Seine, \[Dm]la Seine
+      \[Dm]Tu n'es pas saoul, \[B&]Paris est sous
+      \[F]La Seine, \[A]la Seine, \[Dm]la Seine
     \end{verse}
   \end{repeatedchords}
 
   \begin{chorus}
-    \[Am]Je ne sais, ne sais, ne sais \[F]pas pourquoi
-    C'est comme \[C]ça, la \[E]Seine et \[Am]moi
-    \[Am]Je ne sais, ne sais, ne sais \[F]pas pourquoi
-    On s'aime comme \[C]ça, la \[E]Seine et \[Am]moi
+    \[Dm]Je ne sais, ne sais, ne sais \[B&]pas pourquoi
+    C'est comme \[F]ça, la \[A]Seine et \[Dm]moi
+    \[Dm]Je ne sais, ne sais, ne sais \[B&]pas pourquoi
+    On s'aime comme \[F]ça, la \[A]Seine et \[Dm]moi
   \end{chorus}
 
   \begin{verse}
@@ -45,15 +45,22 @@
     Extravagante quand l'ange est sur
     La Seine, la Seine, la Seine
   \end{verse}
-
+ Dm                D7    Gm             A7              
+   Sur le pont des arts,    mon coeur vacille
+ Bb           C     D               D 
+   Entre deux eaux,    l'air est si bon
+ Dm           D7   Gm          A7        
+   Cet air si pur,    je le respire
+ Bbmaj7        Bbmaj7         Bbmaj7     Bbmaj7     
+   Nos reflets perchés sur ce pont
   \begin{bridge}
-    \[A]Sur l'pont des arts
-    \[D]Mon cœur vac\[E]ille
-    \[F]Entre deux \[G]eaux
-    \[A]L'air est si bon
-    \[A]Cet air si pur
-    \[D]Je le resp\[E]ire
-    \[F]Nos reflets \[G]perchés sur ce \[A]pont
+    \[Dm]Sur l'pont des \[E7]arts
+    \[Gm]Mon cœur vac\[A7]ille
+    \[B&]Entre deux \[C]eaux
+    \[D]L'air est si bon
+    \[Dm]Cet air si \[D7]pur
+    \[Gm]Je le resp\[A7]ire
+    \[B&]Nos reflets perchés sur ce pont
   \end{bridge}
 
   \begin{verse*}

--- a/songs/simon_garfunkel/scarborough_fair.sg
+++ b/songs/simon_garfunkel/scarborough_fair.sg
@@ -4,16 +4,16 @@
   [by={Simon\ \&\ Garfunkel},cov={the-definitive},album={The definitive}]
 
   \cover
-  \gtab{Am}{X02210}
   \gtab{Em}{022000}
-  \gtab{C}{X32010}
-  \gtab{G}{320003}
+  \gtab{Bm}{224432}
+  \gtab{A}{002220}
+  \gtab{D}{X00232}
 
   \begin{chorus}
-    \[Am]Are you going to \[Em]Scarborough \[Am]Fair
-    \[C] Parsley, \[Am]sage, rose\[C]ma\[D]ry and \[Am]thyme
-    Remember \[C]me to one who lives \[G]there
-    \[Am]She once \[G]was a \[Am]true love \[Em]of \[Am]mine
+    \[Em]Are you going to \[Bm]Scarborough \[Em]Fair
+    \[Em]Parsley, sage, rose\[A]mary and \[Em]thyme
+    \[Em]Remember \[Bm]me to \[Em]one who lives \[D]there
+    \[Em]She once \[D]was a \[Bm]true love of \[Em]mine
   \end{chorus}
 
   \begin{verse}


### PR DESCRIPTION
Plusieurs chansons sont disponibles dans le carnet en La mineur, alors que leur tonalité originale est différente. Cette PR se propose d'en corriger quelques unes.

Elle n'est pas prête à être mergée, j'ouvre simplement la PR pour en discuter.

Le problème principal d'avoir ces chants en Lam et pas dans la tonalité réelle est qu'ils sont souvent plus difficiles à chanter en Lam, même si cette tonalité est plus pratique pour la guitare.